### PR TITLE
Use theme color for chat settings button

### DIFF
--- a/lib/components/channel_panel.dart
+++ b/lib/components/channel_panel.dart
@@ -128,7 +128,7 @@ class ChannelPanelWidget extends StatelessWidget {
                 ),
               ),
               PopupMenuButton<String>(
-                icon: const Icon(Icons.build, color: Colors.white),
+                icon: const Icon(Icons.build),
                 onSelected: (value) async {
                   if (value == "Clear Chat") {
                     final channelsModel =


### PR DESCRIPTION
This makes the chat settings icon visible when using light mode.