### PR TITLE
Update agent references to the firebase project id

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -1,13 +1,17 @@
-import * as admin from "firebase-admin";
 import { Message, PubSub } from "@google-cloud/pubsub";
-import * as dotenv from "dotenv";
 import Bottleneck from "bottleneck";
+import * as dotenv from "dotenv";
+import * as admin from "firebase-admin";
 import { v4 as uuidv4 } from "uuid";
+import * as serviceAccount from "../service_account.json";
 import { buildClient } from "./client";
 
 dotenv.config();
+
+const PROJECT_ID = serviceAccount.project_id;
+
 admin.initializeApp({
-  databaseURL: "https://rtchat-47692-default-rtdb.firebaseio.com",
+  databaseURL: `https://${PROJECT_ID}-default-rtdb.firebaseio.com`,
 });
 
 const AGENT_ID = uuidv4();
@@ -114,19 +118,19 @@ async function onUnsubscribe(message: Message) {
   }
 }
 
-const JOIN_TOPIC = new PubSub().topic("projects/rtchat-47692/topics/subscribe");
+const JOIN_TOPIC = new PubSub().topic(`projects/${PROJECT_ID}/topics/subscribe`);
 
 const JOIN_SUBSCRIPTION = JOIN_TOPIC.subscription(
-  "projects/rtchat-47692/subscriptions/subscribe-sub"
+  `projects/${PROJECT_ID}/subscriptions/subscribe-sub`
 );
 
 JOIN_SUBSCRIPTION.on("message", onSubscribe);
 
 const LEAVE_TOPIC = new PubSub().topic(
-  "projects/rtchat-47692/topics/unsubscribe"
+  `projects/${PROJECT_ID}/topics/unsubscribe`
 );
 
-const LEAVE_SUBSCRIPTION_ID = `projects/rtchat-47692/subscriptions/unsubscribe-${AGENT_ID}`;
+const LEAVE_SUBSCRIPTION_ID = `projects/${PROJECT_ID}/subscriptions/unsubscribe-${AGENT_ID}`;
 
 (async function () {
   const [subscription] = await LEAVE_TOPIC.createSubscription(

--- a/agent/tsconfig.json
+++ b/agent/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "resolveJsonModule": true,
     "types": ["node"]
   }
 }


### PR DESCRIPTION
This uses the service account to retrieve the project id and set it to the different pub/sub resources the agent uses.

I guess something similar could be done to some strings in the functions directory.

Note: I think using .env could be an alternative... but would require setting up `service_account.json` plus `.env` so maybe just using the json file is easier.

Also, can I remove the `build` script in `package.json`? Considering `run` uses ts-node and not the output of build.