### PR TITLE
feat: add status indicator to channel switch

### DIFF
--- a/lib/components/channel_search_dialog.dart
+++ b/lib/components/channel_search_dialog.dart
@@ -90,8 +90,18 @@ class _ChannelSearchDialogState extends State<ChannelSearchDialog> {
                 child: ListView(
                     children: data.map((result) {
               return ListTile(
-                  leading: CircleAvatar(
-                      foregroundImage: NetworkImage(result.imageUrl)),
+                  leading: Container(
+                    child: CircleAvatar(
+                      backgroundImage: NetworkImage(result.imageUrl),
+                    ),
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      border: Border.all(
+                        color: result.isOnline ? Colors.green : Colors.red,
+                        width: 2.0,
+                      ),
+                    ),
+                  ),
                   title: Text(result.displayName),
                   subtitle: Text(result.title),
                   onTap: () {


### PR DESCRIPTION
This adds a border decoration to the channel's image when using the channel switcher, the border is colored depending on the channel status.

[Before](https://user-images.githubusercontent.com/994594/125975145-ca84a9cf-fef2-47f4-bc0c-e4e87b8c6325.jpg)
[After - Light](https://user-images.githubusercontent.com/994594/125975148-1191b818-78d6-4ad4-b94c-6666b492521c.jpg)
[After - Dark](https://user-images.githubusercontent.com/994594/125975011-fb278c5b-f829-43b6-85d6-55741faf2b0f.png)