### PR TITLE
fix: use theme color for stream events

### DIFF
--- a/lib/components/chat_history/stream_state_event.dart
+++ b/lib/components/chat_history/stream_state_event.dart
@@ -23,7 +23,7 @@ class StreamStateEventWidget extends StatelessWidget {
                       : "Stream offline at $date, $time",
                   textAlign: TextAlign.center,
                 )),
-            color: Colors.grey[900],
+            color: Theme.of(context).dividerColor,
             width: double.infinity));
   }
 }


### PR DESCRIPTION
Fixes the stream events widget for light mode.

[Light Mode - before](https://user-images.githubusercontent.com/994594/126020675-e17b4eea-9d3c-48f0-ac58-d953f744a9f2.jpg)
[Light Mode - after](https://user-images.githubusercontent.com/994594/126020646-aaade1a6-45cb-458a-96f8-6383444793dc.jpg)
[Dark Mode](https://user-images.githubusercontent.com/994594/126020700-51cf7f71-7b01-4a76-b887-00fd6f1dc8f7.png)


