### PR TITLE
feat: always enable speaker disconnect protection

### DIFF
--- a/lib/models/audio.dart
+++ b/lib/models/audio.dart
@@ -42,7 +42,7 @@ class AudioSource {
 class AudioModel extends ChangeNotifier {
   final List<AudioSource> _sources = [];
   final Map<AudioSource, HeadlessInAppWebView> _views = {};
-  Timer? _speakerDisconnectTimer;
+  late final Timer _speakerDisconnectTimer;
   final _audioCache = AudioCache();
   final initialOptions = InAppWebViewGroupOptions(
       crossPlatform: InAppWebViewOptions(
@@ -55,22 +55,9 @@ class AudioModel extends ChangeNotifier {
   @override
   void dispose() {
     _hostChannelStateSubscription?.cancel();
+    _speakerDisconnectTimer.cancel();
 
     super.dispose();
-  }
-
-  bool get isSpeakerDisconnectPreventionEnabled {
-    return _speakerDisconnectTimer != null;
-  }
-
-  set isSpeakerDisconnectPreventionEnabled(bool isEnabled) {
-    if (isEnabled) {
-      _startSpeakerDisconnectTimer();
-    } else {
-      _speakerDisconnectTimer?.cancel();
-      _speakerDisconnectTimer = null;
-    }
-    notifyListeners();
   }
 
   bool get isForegroundServiceEnabled => _isForegroundServiceEnabled;
@@ -110,13 +97,6 @@ class AudioModel extends ChangeNotifier {
             ForegroundServiceChannel.stop();
           }
         });
-  }
-
-  void _startSpeakerDisconnectTimer() {
-    _speakerDisconnectTimer = Timer.periodic(
-      const Duration(minutes: 5),
-      (_) => _audioCache.play("silence.mp3"),
-    );
   }
 
   List<AudioSource> get sources => _sources;
@@ -168,14 +148,15 @@ class AudioModel extends ChangeNotifier {
   }
 
   AudioModel.fromJson(Map<String, dynamic> json) {
+    _speakerDisconnectTimer = Timer.periodic(
+      const Duration(minutes: 5),
+      (_) => _audioCache.play("silence.mp3"),
+    );
     final sources = json['sources'];
     if (sources != null) {
       for (dynamic source in sources) {
         addSource(AudioSource.fromJson(source));
       }
-    }
-    if (json['isSpeakerDisconnectPreventionEnabled'] ?? false) {
-      _startSpeakerDisconnectTimer();
     }
     if (json['isForegroundServiceEnabled'] ?? false) {
       _isForegroundServiceEnabled = json['isForegroundServiceEnabled'];
@@ -185,7 +166,6 @@ class AudioModel extends ChangeNotifier {
 
   Map<String, dynamic> toJson() => {
         "sources": _sources.map((source) => source.toJson()).toList(),
-        "isSpeakerDisconnectPreventionEnabled": _speakerDisconnectTimer != null,
         "isForegroundServiceEnabled": _isForegroundServiceEnabled,
       };
 }

--- a/lib/screens/settings/audio_sources.dart
+++ b/lib/screens/settings/audio_sources.dart
@@ -36,17 +36,6 @@ class _AudioSourcesScreenState extends State<AudioSourcesScreen> {
       body: Column(children: [
         Consumer<AudioModel>(builder: (context, audioModel, child) {
           return SwitchListTile.adaptive(
-            title: const Text('Speaker disconnect prevention'),
-            subtitle:
-                const Text('Prevent bluetooth speakers from disconnecting'),
-            value: audioModel.isSpeakerDisconnectPreventionEnabled,
-            onChanged: (value) {
-              audioModel.isSpeakerDisconnectPreventionEnabled = value;
-            },
-          );
-        }),
-        Consumer<AudioModel>(builder: (context, audioModel, child) {
-          return SwitchListTile.adaptive(
             title: const Text('Keep app running in the background when online'),
             subtitle: audioModel.isForegroundServiceEnabled
                 ? const Text(


### PR DESCRIPTION
I don't really know why you would ever _not_ want speaker disconnect protection, perhaps we should keep it always enabled?