### PR TITLE
fix: use Colors.grey[900] instead of dividerColor

### DIFF
--- a/lib/components/pinnable/scroll_view.dart
+++ b/lib/components/pinnable/scroll_view.dart
@@ -56,7 +56,7 @@ class PinnableMessageScrollView extends ScrollView {
         child: AnimatedContainer(
           duration: const Duration(milliseconds: 300),
           curve: Curves.easeOut,
-          color: pinned ? Theme.of(context).dividerColor : Colors.transparent,
+          color: pinned ? Colors.grey[900] : Colors.transparent,
           child: itemBuilder(nextPinnableIndex),
         ),
       );


### PR DESCRIPTION
Apparently `dividerColor` is done via alpha transparency instead of being the correct grey color.