### PR TITLE
feat: add sub events to chat history

### DIFF
--- a/lib/components/chat_history/message.dart
+++ b/lib/components/chat_history/message.dart
@@ -6,11 +6,17 @@ import 'package:rtchat/components/chat_history/stream_state_event.dart';
 import 'package:rtchat/components/chat_history/timeout_dialog.dart';
 import 'package:rtchat/components/chat_history/twitch/message.dart';
 import 'package:rtchat/components/chat_history/twitch/raid_event.dart';
+import 'package:rtchat/components/chat_history/twitch/subscription_event.dart';
+import 'package:rtchat/components/chat_history/twitch/subscription_gift_event.dart';
+import 'package:rtchat/components/chat_history/twitch/subscription_message_event.dart';
 import 'package:rtchat/models/channels.dart';
 import 'package:rtchat/models/layout.dart';
 import 'package:rtchat/models/message.dart';
 import 'package:rtchat/models/twitch/event.dart';
 import 'package:rtchat/models/twitch/message.dart';
+import 'package:rtchat/models/twitch/subscription_event.dart';
+import 'package:rtchat/models/twitch/subscription_gift_event.dart';
+import 'package:rtchat/models/twitch/subscription_message_event.dart';
 import 'package:rtchat/models/user.dart';
 
 class ChatHistoryMessage extends StatelessWidget {
@@ -119,6 +125,12 @@ class ChatHistoryMessage extends StatelessWidget {
       });
     } else if (m is TwitchRaidEventModel) {
       return TwitchRaidEventWidget(m);
+    } else if (m is TwitchSubscriptionEventModel) {
+      return kDebugMode ? TwitchSubscriptionEventWidget(m) : Container();
+    } else if (m is TwitchSubscriptionGiftEventModel) {
+      return kDebugMode ? TwitchSubscriptionGiftEventWidget(m) : Container();
+    } else if (m is TwitchSubscriptionMessageEventModel) {
+      return kDebugMode ? TwitchSubscriptionMessageEventWidget(m) : Container();
     } else if (m is StreamStateEventModel) {
       return StreamStateEventWidget(m);
     } else {

--- a/lib/components/chat_history/twitch/subscription_event.dart
+++ b/lib/components/chat_history/twitch/subscription_event.dart
@@ -32,10 +32,7 @@ class TwitchSubscriptionEventWidget extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.fromLTRB(12, 4, 16, 4),
           child: Row(children: [
-            ClipRRect(
-              borderRadius: BorderRadius.circular(styleModel.fontSize),
-              child: Icon(Icons.star, size: styleModel.fontSize * 1.5),
-            ),
+            Icon(Icons.star, size: styleModel.fontSize * 1.5),
             const SizedBox(width: 12),
             Expanded(
               child: RichText(

--- a/lib/components/chat_history/twitch/subscription_event.dart
+++ b/lib/components/chat_history/twitch/subscription_event.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:provider/provider.dart';
+import 'package:rtchat/models/style.dart';
+import 'package:rtchat/models/twitch/subscription_event.dart';
+
+class TwitchSubscriptionEventWidget extends StatelessWidget {
+  final TwitchSubscriptionEventModel model;
+
+  const TwitchSubscriptionEventWidget(this.model, {Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<StyleModel>(builder: (context, styleModel, child) {
+      var boldStyle = Theme.of(context)
+          .textTheme
+          .bodyText2!
+          .copyWith(fontSize: styleModel.fontSize, fontWeight: FontWeight.w500);
+      var baseStyle = Theme.of(context)
+          .textTheme
+          .bodyText2!
+          .copyWith(fontSize: styleModel.fontSize);
+      return Container(
+        decoration: BoxDecoration(
+          border: Border(
+            left: BorderSide(
+              width: 4,
+              color: Theme.of(context).accentColor,
+            ),
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(12, 4, 16, 4),
+          child: Row(children: [
+            ClipRRect(
+              borderRadius: BorderRadius.circular(styleModel.fontSize),
+              child: Icon(Icons.star, size: styleModel.fontSize * 1.5),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: RichText(
+                text: TextSpan(
+                  children: [
+                    TextSpan(text: model.subscriberUserName, style: boldStyle),
+                    TextSpan(
+                        text:
+                            " subscribed at Tier ${model.tier.replaceAll("000", "")}.",
+                        style: baseStyle),
+                  ],
+                ),
+              ),
+            )
+          ]),
+        ),
+      );
+    });
+  }
+}

--- a/lib/components/chat_history/twitch/subscription_gift_event.dart
+++ b/lib/components/chat_history/twitch/subscription_gift_event.dart
@@ -33,10 +33,7 @@ class TwitchSubscriptionGiftEventWidget extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.fromLTRB(12, 4, 16, 4),
           child: Row(children: [
-            ClipRRect(
-              borderRadius: BorderRadius.circular(styleModel.fontSize),
-              child: Icon(Icons.star, size: styleModel.fontSize * 1.5),
-            ),
+            Icon(Icons.star, size: styleModel.fontSize * 1.5),
             const SizedBox(width: 12),
             Expanded(
               child: RichText(

--- a/lib/components/chat_history/twitch/subscription_gift_event.dart
+++ b/lib/components/chat_history/twitch/subscription_gift_event.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:provider/provider.dart';
+import 'package:rtchat/models/style.dart';
+import 'package:rtchat/models/twitch/subscription_gift_event.dart';
+
+class TwitchSubscriptionGiftEventWidget extends StatelessWidget {
+  final TwitchSubscriptionGiftEventModel model;
+
+  const TwitchSubscriptionGiftEventWidget(this.model, {Key? key})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<StyleModel>(builder: (context, styleModel, child) {
+      var boldStyle = Theme.of(context)
+          .textTheme
+          .bodyText2!
+          .copyWith(fontSize: styleModel.fontSize, fontWeight: FontWeight.w500);
+      var baseStyle = Theme.of(context)
+          .textTheme
+          .bodyText2!
+          .copyWith(fontSize: styleModel.fontSize);
+      return Container(
+        decoration: BoxDecoration(
+          border: Border(
+            left: BorderSide(
+              width: 4,
+              color: Theme.of(context).accentColor,
+            ),
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(12, 4, 16, 4),
+          child: Row(children: [
+            ClipRRect(
+              borderRadius: BorderRadius.circular(styleModel.fontSize),
+              child: Icon(Icons.star, size: styleModel.fontSize * 1.5),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: RichText(
+                text: TextSpan(
+                  children: [
+                    TextSpan(text: model.gifterUserName, style: boldStyle),
+                    TextSpan(
+                        text:
+                            " gifted ${model.total} Tier ${model.tier.replaceAll("000", "")} ",
+                        style: baseStyle),
+                    TextSpan(
+                        text: model.total > 1
+                            ? "subscriptions."
+                            : "subscription.",
+                        style: baseStyle),
+                  ],
+                ),
+              ),
+            )
+          ]),
+        ),
+      );
+    });
+  }
+}

--- a/lib/components/chat_history/twitch/subscription_message_event.dart
+++ b/lib/components/chat_history/twitch/subscription_message_event.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:provider/provider.dart';
+import 'package:rtchat/models/style.dart';
+import 'package:rtchat/models/twitch/subscription_message_event.dart';
+
+class TwitchSubscriptionMessageEventWidget extends StatelessWidget {
+  final TwitchSubscriptionMessageEventModel model;
+
+  const TwitchSubscriptionMessageEventWidget(this.model, {Key? key})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<StyleModel>(builder: (context, styleModel, child) {
+      var boldStyle = Theme.of(context)
+          .textTheme
+          .bodyText2!
+          .copyWith(fontSize: styleModel.fontSize, fontWeight: FontWeight.w500);
+      var baseStyle = Theme.of(context)
+          .textTheme
+          .bodyText2!
+          .copyWith(fontSize: styleModel.fontSize);
+      return Container(
+        decoration: BoxDecoration(
+          border: Border(
+            left: BorderSide(
+              width: 4,
+              color: Theme.of(context).accentColor,
+            ),
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(12, 4, 16, 4),
+          child: Row(children: [
+            ClipRRect(
+              borderRadius: BorderRadius.circular(styleModel.fontSize),
+              child: Icon(Icons.star, size: styleModel.fontSize * 1.5),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: RichText(
+                text: TextSpan(
+                  children: [
+                    TextSpan(text: model.subscriberUserName, style: boldStyle),
+                    TextSpan(
+                        text:
+                            " subscribed at Tier ${model.tier.replaceAll("000", "")}. They've subscribed for ",
+                        style: baseStyle),
+                    TextSpan(
+                        text: "${model.durationMonths} months",
+                        style: boldStyle),
+                    TextSpan(
+                        text: model.streakMonths > 1
+                            ? ", currently on a ${model.streakMonths} month streak!"
+                            : "!",
+                        style: baseStyle),
+                  ],
+                ),
+              ),
+            )
+          ]),
+        ),
+      );
+    });
+  }
+}

--- a/lib/components/chat_history/twitch/subscription_message_event.dart
+++ b/lib/components/chat_history/twitch/subscription_message_event.dart
@@ -33,10 +33,7 @@ class TwitchSubscriptionMessageEventWidget extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.fromLTRB(12, 4, 16, 4),
           child: Row(children: [
-            ClipRRect(
-              borderRadius: BorderRadius.circular(styleModel.fontSize),
-              child: Icon(Icons.star, size: styleModel.fontSize * 1.5),
-            ),
+            Icon(Icons.star, size: styleModel.fontSize * 1.5),
             const SizedBox(width: 12),
             Expanded(
               child: RichText(

--- a/lib/models/chat_history.dart
+++ b/lib/models/chat_history.dart
@@ -9,6 +9,9 @@ import 'package:rtchat/models/message.dart';
 import 'package:rtchat/models/tts.dart';
 import 'package:rtchat/models/twitch/event.dart';
 import 'package:rtchat/models/twitch/message.dart';
+import 'package:rtchat/models/twitch/subscription_event.dart';
+import 'package:rtchat/models/twitch/subscription_gift_event.dart';
+import 'package:rtchat/models/twitch/subscription_message_event.dart';
 import 'package:rtchat/models/twitch/user.dart';
 
 class ChatHistoryModel extends ChangeNotifier {
@@ -128,6 +131,98 @@ class ChatHistoryModel extends ChangeNotifier {
                 notifyListeners();
               });
             }
+            break;
+          case "channel.subscribe":
+            final index = _events.length;
+            final DateTime timestamp = data['timestamp'].toDate();
+            final expiration = timestamp.add(const Duration(seconds: 15));
+            final remaining = expiration.difference(DateTime.now());
+
+            final model = TwitchSubscriptionEventModel(
+                pinned: remaining > Duration.zero,
+                messageId: change.doc.id,
+                subscriberUserName: data['event']['user_name'],
+                isGift: data['event']['is_gift'],
+                tier: data['event']['tier']);
+
+            _events.add(model);
+
+            if (remaining > Duration.zero) {
+              Timer(remaining, () {
+                _events[index] = TwitchSubscriptionEventModel(
+                    pinned: false,
+                    messageId: change.doc.id,
+                    subscriberUserName: data['event']['user_name'],
+                    isGift: data['event']['is_gift'],
+                    tier: data['event']['tier']);
+                notifyListeners();
+              });
+            }
+
+            break;
+          case "channel.subscription.gift":
+            final index = _events.length;
+            final DateTime timestamp = data['timestamp'].toDate();
+            final expiration = timestamp.add(const Duration(seconds: 15));
+            final remaining = expiration.difference(DateTime.now());
+
+            final gifterName = data['event']['is_anonymous']
+                ? "Anonymous Gifter"
+                : data['event']['user_name'];
+
+            final model = TwitchSubscriptionGiftEventModel(
+                pinned: remaining > Duration.zero,
+                messageId: change.doc.id,
+                gifterUserName: gifterName,
+                tier: data['event']['tier'],
+                total: data['event']['total']);
+
+            _events.add(model);
+
+            if (remaining > Duration.zero) {
+              Timer(remaining, () {
+                _events[index] = TwitchSubscriptionGiftEventModel(
+                    pinned: false,
+                    messageId: change.doc.id,
+                    gifterUserName: gifterName,
+                    tier: data['event']['tier'],
+                    total: data['event']['total']);
+                notifyListeners();
+              });
+            }
+
+            break;
+          case "channel.subscription.message":
+            final index = _events.length;
+            final DateTime timestamp = data['timestamp'].toDate();
+            final expiration = timestamp.add(const Duration(seconds: 15));
+            final remaining = expiration.difference(DateTime.now());
+
+            final model = TwitchSubscriptionMessageEventModel(
+                pinned: remaining > Duration.zero,
+                messageId: change.doc.id,
+                subscriberUserName: data['event']['user_name'],
+                tier: data['event']['tier'],
+                streakMonths: data['event']['streak_months'],
+                cumulativeMonths: data['event']['cumulative_months'],
+                durationMonths: data['event']['duration_months']);
+
+            _events.add(model);
+
+            if (remaining > Duration.zero) {
+              Timer(remaining, () {
+                _events[index] = TwitchSubscriptionMessageEventModel(
+                    pinned: false,
+                    messageId: change.doc.id,
+                    subscriberUserName: data['event']['user_name'],
+                    tier: data['event']['tier'],
+                    streakMonths: data['event']['streak_months'],
+                    cumulativeMonths: data['event']['cumulative_months'],
+                    durationMonths: data['event']['duration_months']);
+                notifyListeners();
+              });
+            }
+
             break;
           case "stream.online":
           case "stream.offline":

--- a/lib/models/chat_history.dart
+++ b/lib/models/chat_history.dart
@@ -222,7 +222,7 @@ class ChatHistoryModel extends ChangeNotifier {
                 notifyListeners();
               });
             }
-            
+
             break;
           case "channel.follow":
             final model = TwitchFollowEventModel(

--- a/lib/models/twitch/subscription_event.dart
+++ b/lib/models/twitch/subscription_event.dart
@@ -1,0 +1,15 @@
+import 'package:rtchat/models/message.dart';
+
+class TwitchSubscriptionEventModel extends MessageModel {
+  final String subscriberUserName;
+  final bool isGift;
+  final String tier;
+
+  const TwitchSubscriptionEventModel(
+      {required bool pinned,
+      required String messageId,
+      required this.subscriberUserName,
+      required this.isGift,
+      required this.tier})
+      : super(messageId: messageId, pinned: pinned);
+}

--- a/lib/models/twitch/subscription_gift_event.dart
+++ b/lib/models/twitch/subscription_gift_event.dart
@@ -1,0 +1,15 @@
+import 'package:rtchat/models/message.dart';
+
+class TwitchSubscriptionGiftEventModel extends MessageModel {
+  final String gifterUserName;
+  final String tier;
+  final int total;
+
+  const TwitchSubscriptionGiftEventModel(
+      {required bool pinned,
+      required String messageId,
+      required this.gifterUserName,
+      required this.tier,
+      required this.total})
+      : super(messageId: messageId, pinned: pinned);
+}

--- a/lib/models/twitch/subscription_message_event.dart
+++ b/lib/models/twitch/subscription_message_event.dart
@@ -1,0 +1,19 @@
+import 'package:rtchat/models/message.dart';
+
+class TwitchSubscriptionMessageEventModel extends MessageModel {
+  final String subscriberUserName;
+  final String tier;
+  final int cumulativeMonths;
+  final int durationMonths;
+  final int streakMonths;
+
+  const TwitchSubscriptionMessageEventModel(
+      {required bool pinned,
+      required String messageId,
+      required this.subscriberUserName,
+      required this.tier,
+      required this.cumulativeMonths,
+      required this.durationMonths,
+      required this.streakMonths})
+      : super(messageId: messageId, pinned: pinned);
+}


### PR DESCRIPTION
This adds subscription events to the chat history.

Note: For now, the message sent with resubs is not handled.

[Light Mode](https://user-images.githubusercontent.com/994594/128444867-c98b18ab-087c-4731-a5d7-df3d87459344.jpg)
[Dark Mode](https://user-images.githubusercontent.com/994594/128447108-a18c823f-4cc9-45c6-bd28-05c18d8808db.png)

Side note: Would it make sense to randomize the color of the BorderSide to more easily differentiate each event? (probably from a defined set of colors that work with each theme)


