### PR TITLE
fix: display cumulative months instead of duration for subscriptions

### DIFF
--- a/lib/components/chat_history/twitch/subscription_message_event.dart
+++ b/lib/components/chat_history/twitch/subscription_message_event.dart
@@ -45,7 +45,7 @@ class TwitchSubscriptionMessageEventWidget extends StatelessWidget {
                             " subscribed at Tier ${model.tier.replaceAll("000", "")}. They've subscribed for ",
                         style: baseStyle),
                     TextSpan(
-                        text: "${model.durationMonths} months",
+                        text: "${model.cumulativeMonths} months",
                         style: boldStyle),
                     TextSpan(
                         text: model.streakMonths > 1


### PR DESCRIPTION
Cumulative Months: The total number of months the user has been subscribed to the channel.